### PR TITLE
VPC Flow Logs - Random Log Area

### DIFF
--- a/modules/aws/vpc/README.md
+++ b/modules/aws/vpc/README.md
@@ -12,7 +12,6 @@ traffic, this is good from an auditing perspective, however you will be charged 
 
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
 | Name | Version |
@@ -69,7 +68,6 @@ traffic, this is good from an auditing perspective, however you will be charged 
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | A list of the private subnet IDs that have been created. This output is of type `list(string)`. |
 | <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | A list of the public subnet IDs that have been created. This output is of type `list(string)`. |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC that has been created. This output is of type `list(string)`. |
-
 <!-- END_TF_DOCS -->
 
 # Example Usage

--- a/modules/aws/vpc/README.md
+++ b/modules/aws/vpc/README.md
@@ -13,12 +13,14 @@ See image for an example structure when the region in the provider is set to `eu
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.4.3 |
 
 ## Resources
 
@@ -34,6 +36,7 @@ See image for an example structure when the region in the provider is set to `eu
 | [aws_subnet.private_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.public_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [random_uuid.log_group_guid_identifier](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs

--- a/modules/aws/vpc/README.md
+++ b/modules/aws/vpc/README.md
@@ -85,11 +85,12 @@ module "vpc_subnet" {
 }
 
 module "vpc_subnet" {
-  source              = "github.com/answerdigital/terraform-modules//modules/aws/vpc?ref=v1.0.0"
-  owner               = "joe_blogs"
-  project_name        = "example_project_name"
-  azs                 = ["eu-west-1", "eu-west-3"]
-  num_public_subnets  = 1
-  num_private_subnets = 2
+  source               = "github.com/answerdigital/terraform-modules//modules/aws/vpc?ref=v1.0.0"
+  owner                = "joe_blogs"
+  project_name         = "example_project_name"
+  azs                  = ["eu-west-1", "eu-west-3"]
+  num_public_subnets   = 1
+  num_private_subnets  = 2
+  enable_vpc_flow_logs = true
 }
 ```

--- a/modules/aws/vpc/README.md
+++ b/modules/aws/vpc/README.md
@@ -7,7 +7,12 @@ See image for an example structure when the region in the provider is set to `eu
 
 ![VPC Subnet Module Diagram](vpc_subnet_module_diagram.svg?raw=true "VPC Subnet Module Diagram")
 
+The option `enable_vpc_flow_logs` must be selected to decide whether you want to include Cloudwatch logging of your VPC
+traffic, this is good from an auditing perspective, however you will be charged for the required Cloudwatch storage.
+
+
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
 | Name | Version |
@@ -64,6 +69,7 @@ See image for an example structure when the region in the provider is set to `eu
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | A list of the private subnet IDs that have been created. This output is of type `list(string)`. |
 | <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | A list of the public subnet IDs that have been created. This output is of type `list(string)`. |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC that has been created. This output is of type `list(string)`. |
+
 <!-- END_TF_DOCS -->
 
 # Example Usage
@@ -78,19 +84,23 @@ repository you can specify a version by appending the below source reference wit
 [here](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories))
 
 ```hcl
-module "vpc_subnet" {
-  source       = "github.com/answerdigital/terraform-modules//modules/aws/vpc?ref=v1.0.0"
-  owner        = "joe_blogs"
-  project_name = "example_project_name"
-}
-
-module "vpc_subnet" {
-  source               = "github.com/answerdigital/terraform-modules//modules/aws/vpc?ref=v1.0.0"
+module "vpc_subnet" "mandatory" {
+  source               = "github.com/answerdigital/terraform-modules/modules/aws/vpc?ref=vx.x.x"
   owner                = "joe_blogs"
   project_name         = "example_project_name"
-  azs                  = ["eu-west-1", "eu-west-3"]
-  num_public_subnets   = 1
-  num_private_subnets  = 2
   enable_vpc_flow_logs = true
+}
+
+module "vpc_subnet" "all" {
+  source                     = "github.com/answerdigital/terraform-modules/modules/aws/vpc?ref=vx.x.x"
+  owner                      = "joe_blogs"
+  project_name               = "example_project_name"
+  azs                        = ["eu-west-1", "eu-west-3"]
+  num_public_subnets         = 1
+  num_private_subnets        = 2
+  enable_vpc_flow_logs       = true
+  vpc_flow_logs_traffic_type = "ALL"
+  enable_dns_support         = true
+  enable_dns_hostnames       = true
 }
 ```

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -1,5 +1,12 @@
 terraform {
   required_version = "~> 1.3"
+
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.4.3"
+    }
+  }
 }
 
 resource "aws_flow_log" "flow_log" {
@@ -10,8 +17,11 @@ resource "aws_flow_log" "flow_log" {
   count           = var.enable_vpc_flow_logs ? 1 : 0
 }
 
+resource "random_uuid" "log_group_guid_identifier" {
+}
+
 resource "aws_cloudwatch_log_group" "log_group" {
-  name  = "${var.project_name}-vpc-flow-logs"
+  name  = "${var.project_name}-vpc-flow-logs-${random_uuid.log_group_guid_identifier.result}"
   count = var.enable_vpc_flow_logs ? 1 : 0
 }
 
@@ -47,7 +57,6 @@ resource "aws_iam_role_policy" "iam_role_policy" {
   "Statement": [
     {
       "Action": [
-        "logs:CreateLogGroup",
         "logs:CreateLogStream",
         "logs:PutLogEvents",
         "logs:DescribeLogGroups",

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -31,7 +31,7 @@ variable "vpc_flow_logs_traffic_type" {
   }
 }
 
-
+# DNS Support
 variable "enable_dns_support" {
   type        = bool
   description = "This allows AWS DNS support to be switched on or off."
@@ -64,6 +64,7 @@ variable "num_private_subnets" {
   default     = -1
 }
 
+# CIDR Defintions
 variable "ig_cidr" {
   type        = string
   description = "This specifies the CIDR block for the internet gateway."


### PR DESCRIPTION
There is a bug at the moment in which if a VPC is created then it will flush the logs potentially after the log group has gone and because it has access to Create Log groups it will create that log group and then be unable to be destroyed as it's not tied to the Terraform State

There's two aspects to this fix

- Use a GUID to create a separate identity for the logs
- Delete the Create Log Group Permission from the IAM policy (It doesn't need it)