### PR TITLE
Version tagger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Update major version tag
+
+permissions:
+  contents: write
+
+on:
+  release:
+    types:
+      - published
+      - edited
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-r-us/actions-tagger@v2
+        with:
+          publish_latest_tag: true

--- a/modules/aws/ec2/README.md
+++ b/modules/aws/ec2/README.md
@@ -55,13 +55,16 @@ This Terraform module will produce an EC2 instance which can be accessed via ssh
 
 # Example Usage
 
-Below is an example of how you would call the `ec2_instance` module in your terraform code. Note that when calling it directly from the github repository you can specify a version by appending the below source reference with `?ref=v1.2.0` for version "1.2.0"
-(for further information please see [here](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories)). Here we also give an example of a bash script used to install docker on `Amazon linux`, then create a
-.env file on the instance and finally run a chosen docker image with the .env file.
+Below is an example of how you would call the `ec2_instance` module in your
+terraform code. Note that when calling it directly from the github repository you can specify a
+version by appending the below source reference with `?ref=v2` for the latest v2.x.x release
+(for further information please see [here](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories)).
+
+Here we also give an example of a bash script used to install docker on `Amazon linux`, then create a .env file on the instance and finally run a chosen docker image with the .env file.
 
 ```hcl
 module "ec2_instance_setup" {
-  source                 = "github.com/answerdigital/terraform-modules//modules/aws/ec2?ref=v1.0.0"
+  source                 = "github.com/answerdigital/terraform-modules//modules/aws/ec2?ref=v2"
   project_name           = var.project_name
   owner                  = var.owner
   ami_id                 = var.ami_id

--- a/modules/aws/ec2/README.md
+++ b/modules/aws/ec2/README.md
@@ -1,6 +1,6 @@
 # Terraform EC2 instance Module
 
-This Terraform module will produce an EC2 instance which can be accessed via ssh or session manager via the aws management console. It also allows the possibility of an elastic ip being associated with the EC2 instance.
+This Terraform module will produce an EC2 instance which can be accessed via ssh or session manager via the aws management console. It also allows the possibility of an elastic IP being associated with the EC2 instance.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -56,7 +56,7 @@ This Terraform module will produce an EC2 instance which can be accessed via ssh
 # Example Usage
 
 Below is an example of how you would call the `ec2_instance` module in your
-terraform code. Note that when calling it directly from the github repository you can specify a
+terraform code. Note that when calling it directly from the GitHub repository you can specify a
 version by appending the below source reference with `?ref=v2` for the latest v2.x.x release
 (for further information please see [here](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories)).
 

--- a/modules/aws/rds_serverless_cluster/README.md
+++ b/modules/aws/rds_serverless_cluster/README.md
@@ -71,13 +71,13 @@ These secrets are also set as outputs of the module and can be referenced throug
 
 Below is an example of how you would call the `rds_serverless_cluster` module in your
 terraform code. Note that when calling it directly from the github repository you can specify a
-version by appending the below source reference with `?ref=v1.2.0` for version "1.2.0"
+version by appending the below source reference with `?ref=v2` for the latest v2.x.x release
 (for further information please see
 [here](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories)).
 
 ```hcl
 module "rds_cluster_setup" {
-  source                     = "github.com/answerdigital/terraform-modules//modules/aws/rds_serverless_cluster?ref=v1.0.0"
+  source                     = "github.com/answerdigital/terraform-modules//modules/aws/rds_serverless_cluster?ref=v2"
   project_name               = var.project_name
   owner                      = var.owner
   database_availability_zone = module.vpc_subnet_setup.az_zones[0]

--- a/modules/aws/rds_serverless_cluster/README.md
+++ b/modules/aws/rds_serverless_cluster/README.md
@@ -70,7 +70,7 @@ These secrets are also set as outputs of the module and can be referenced throug
 # Example Usage
 
 Below is an example of how you would call the `rds_serverless_cluster` module in your
-terraform code. Note that when calling it directly from the github repository you can specify a
+terraform code. Note that when calling it directly from the GitHub repository you can specify a
 version by appending the below source reference with `?ref=v2` for the latest v2.x.x release
 (for further information please see
 [here](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories)).

--- a/modules/aws/vpc/README.md
+++ b/modules/aws/vpc/README.md
@@ -78,19 +78,19 @@ the first uses the module to create a public and private subnet on each Availabi
 the second uses the module to create 1 public subnet in the AZ `eu-west-1` and 2 private subnets in `eu-west-1`
 and `eu-west-3` respectively. Note that when calling the module directly from the github
 repository you can specify a version by appending the below source reference with
-`?ref=v1.2.0` for version "1.2.0" (for further information please see
+`?ref=v2` for the latest v2.x.x release (for further information please see
 [here](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories))
 
 ```hcl
 module "vpc_subnet" {
-  source               = "github.com/answerdigital/terraform-modules/modules/aws/vpc?ref=vx.x.x"
+  source               = "github.com/answerdigital/terraform-modules/modules/aws/vpc?ref=v2"
   owner                = "joe_blogs"
   project_name         = "example_project_name"
   enable_vpc_flow_logs = true
 }
 
 module "vpc_subnet" {
-  source                     = "github.com/answerdigital/terraform-modules/modules/aws/vpc?ref=vx.x.x"
+  source                     = "github.com/answerdigital/terraform-modules/modules/aws/vpc?ref=v2"
   owner                      = "joe_blogs"
   project_name               = "example_project_name"
   azs                        = ["eu-west-1", "eu-west-3"]

--- a/modules/aws/vpc/README.md
+++ b/modules/aws/vpc/README.md
@@ -76,7 +76,7 @@ Below are examples of how you would call the `vpc_subnet` module in your terrafo
 In this example we show two ways the module can be used;
 the first uses the module to create a public and private subnet on each Availability Zone in your defined region,
 the second uses the module to create 1 public subnet in the AZ `eu-west-1` and 2 private subnets in `eu-west-1`
-and `eu-west-3` respectively. Note that when calling the module directly from the github
+and `eu-west-3` respectively. Note that when calling the module directly from the GitHub
 repository you can specify a version by appending the below source reference with
 `?ref=v2` for the latest v2.x.x release (for further information please see
 [here](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories))


### PR DESCRIPTION
Automatically updates e.g. `v2` tag to match the latest `v2.x.x` release.