### PR TITLE
Added http_endpoint = enabled to EC2

### DIFF
--- a/modules/aws/ec2/main.tf
+++ b/modules/aws/ec2/main.tf
@@ -56,7 +56,8 @@ resource "aws_instance" "ec2" {
   key_name      = aws_key_pair.key_pair.key_name
   ami           = var.ami_id
   metadata_options {
-    http_tokens = "required"
+    http_endpoint = "enabled"
+    http_tokens   = "required"
   }
   root_block_device {
     encrypted = true


### PR DESCRIPTION
EC2 module was broken because `http_endpoint` is set to '' by default instead of a valid setting, despite being an optional argument. Should now work as I've tested locally.