### PR TITLE
Fix logic for listing modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,24 +42,6 @@ updates:
           - "version-update:semver-patch"
           - "version-update:semver-minor"
   - package-ecosystem: terraform
-    directory: /modules/aws/state_manager/test
-    schedule:
-      interval: daily
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-minor"
-  - package-ecosystem: terraform
-    directory: /modules/aws/state_manager/test/test-state
-    schedule:
-      interval: daily
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-minor"
-  - package-ecosystem: terraform
     directory: /modules/aws/vpc
     schedule:
       interval: daily

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Output all modules
         id: output-all
         run: |
-          JQ_OUTPUT_ALL=$(find modules/ -mindepth 2 -type d | jq -R -s -c 'split("\n")[:-1]')
+          JQ_OUTPUT_ALL=$(find modules -mindepth 2 -maxdepth 2 -type d | jq -MRsc 'split("\n")[:-1]')
           echo "all_modules=$JQ_OUTPUT_ALL" >> $GITHUB_OUTPUT
       - name: Output changed modules
         if: ${{ github.event_name == 'pull_request' }}
@@ -32,7 +32,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           JQ_OUTPUT_CHANGED=$(git diff --name-only $BASE_SHA $GITHUB_SHA modules/*/*/*.tf |
-            cut -d/ -f1-3 | sort -u | jq -R -s -c 'split("\n")[:-1]')
+            cut -d/ -f1-3 | sort -u | jq -MRsc 'split("\n")[:-1]')
           echo "changed_modules=$JQ_OUTPUT_CHANGED" >> $GITHUB_OUTPUT
 
   terraform-check:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -97,7 +97,7 @@ jobs:
     needs:
       - determine-modules
       - terraform-docs # to avoid race condition with both committing
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ always() && github.event_name == 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Logic for listing all modules includes the test directories within modules, which fails the workflow and creates unnecessary entries in dependabot.yml.

Decided to use `-maxdepth 2`, which does enforce the folder structure somewhat, but that's already the case because the `changed_modules` list looks at `modules/*/*/*.tf`. So we can solve both of those together if we ever need to.

Alternatives I considered that don't work:

* `find modules -name main.tf -exec dirname {} \;` - looks good but not every module has a main.tf
* `find modules -name README.md -exec dirname {} \;` - the test folders have readme files too