### PR TITLE
Separate workflow_run job for committing documentation & config

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: main
 
-# for Dependabot terraform-docs
-permissions:
-  contents: write
-
 jobs:
   determine-modules:
     name: "Determine Terraform Modules"
@@ -18,10 +14,9 @@ jobs:
       check_modules: ${{ github.event_name == 'pull_request'
         && steps.output-changed.outputs.changed_modules
         || steps.output-all.outputs.all_modules }}
-      all_modules: ${{ steps.output-all.outputs.all_modules }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Output all modules
@@ -52,7 +47,7 @@ jobs:
         working-directory: "${{ matrix.module }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: hashicorp/setup-terraform@v2
@@ -75,64 +70,3 @@ jobs:
           github_token: ${{ github.token }}
           soft_fail: true
           working_directory: "${{ matrix.module }}"
-
-  terraform-docs:
-    name: "Update Terraform Docs"
-    runs-on: ubuntu-latest
-    needs: terraform-check
-    if: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-
-      - name: Update README files
-        uses: terraform-docs/gh-actions@v1.0.0
-        with:
-          find-dir: "modules"
-          config-file: "${{ github.workspace }}/.terraform-docs.yml"
-          output-method: inject
-          git-push: "true"
-
-  dependabot:
-    name: Update Dependabot Entries
-    runs-on: ubuntu-latest
-    needs:
-      - determine-modules
-      - terraform-docs # to avoid race condition with both committing
-    if: ${{ always() && github.event_name == 'pull_request' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-
-      - name: Update dependabot.yml
-        env:
-          MODULES: ${{ needs.determine-modules.outputs.all_modules }}
-        run: |
-          cp .github/dependabot-base.yml .github/dependabot.yml
-          sed -i '1i # This file is auto-generated from dependabot-base.yml' .github/dependabot.yml
-
-          jq -r '.[]' <<< "$MODULES" | sort | while read MODULE; do
-            cat <<EOF >> .github/dependabot.yml
-            - package-ecosystem: terraform
-              directory: /$MODULE
-              schedule:
-                interval: daily
-              ignore:
-                - dependency-name: "*"
-                  update-types:
-                    - "version-update:semver-patch"
-                    - "version-update:semver-minor"
-          EOF
-          done
-
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Update dependabot terraform entries
-          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-          file_pattern: .github/dependabot.yml
-          skip_checkout: true
-

--- a/.github/workflows/update_assets.yml
+++ b/.github/workflows/update_assets.yml
@@ -1,0 +1,54 @@
+# WARNING: This workflow operates in a privileged context and
+# in case of a pull_request, it checks out untrusted code.
+# Modify with caution.
+
+name: Update assets in PR
+
+on:
+  workflow_run:
+    workflows: Check Terraform
+    types: completed
+
+jobs:
+  update-assets:
+    name: Update Terraform Assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+
+      - name: Update README files
+        uses: terraform-docs/gh-actions@v1.0.0
+        with:
+          find-dir: modules
+          config-file: ${{ github.workspace }}/.terraform-docs.yml
+          output-method: inject
+
+      - name: Update dependabot.yml
+        run: |
+          cp .github/dependabot-base.yml .github/dependabot.yml
+          sed -i '1i # This file is auto-generated from dependabot-base.yml' .github/dependabot.yml
+
+          find modules -mindepth 2 -maxdepth 2 -type d | sort | while read MODULE; do
+            cat <<EOF >> .github/dependabot.yml
+            - package-ecosystem: terraform
+              directory: /$MODULE
+              schedule:
+                interval: daily
+              ignore:
+                - dependency-name: "*"
+                  update-types:
+                    - "version-update:semver-patch"
+                    - "version-update:semver-minor"
+          EOF
+          done
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        continue-on-error: ${{ github.event.workflow_run.event == 'pull_request' }}
+        with:
+          commit_message: Update documentation & dependabot entries
+          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          skip_checkout: true

--- a/.github/workflows/update_assets.yml
+++ b/.github/workflows/update_assets.yml
@@ -13,6 +13,7 @@ jobs:
   update-assets:
     name: Update Terraform Assets
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
As we have seen, `pull_request` workflows when run by a fork don't have write access to commit the documentation/dependabot changes.

Following the advice at https://securitylab.github.com/research/github-actions-preventing-pwn-requests/, I have separated out the privileged actions that require commit access into a `workflow_run` workflow.

Now, the existing workflow only performs the terraform validation checks. When it completes successfully, the second workflow attempts to commit documentation/dependabot changes.

If the PR is internal, or it's from a fork and the contributor has selected "Allow edits by maintainers", the workflow can commit back to the PR. If this commit cannot be completed, the workflow fails silently.

The new workflow runs after both triggers of the existing one (`pull_request` and `push`), so if the documentation updates can't be committed to the PR, they are committed after it is merged.

The second workflow only fails the commit silently in the case of a `pull_request`; if it fails after a `push` for any reason, it will error as expected.

Visual explanation:

```mermaid
graph LR;
  workflowtype{Workflow\ntype?}
  isinternal{Internal\ncontributor?}
  cancontrib{Contributions\nallowed?}
  commitpr[Commit to PR]
  commitpush[Commit after push]
  failsilent[Fail silently]

  workflow_run-->workflowtype;
  workflowtype-->|pull_request|isinternal;
  isinternal-->|Yes|commitpr;
  isinternal-->|No|cancontrib;
  cancontrib-->|Yes|commitpr;
  cancontrib-->|No|failsilent;
  failsilent-.->|Committed after merge|commitpush;
  workflowtype-->|push|commitpush;
```