### PR TITLE
Prepare release v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ You can use these modules in your own terraform projects as follows:
 
 ```hcl
 module "ec2_setup" {
-  source = "github.com/answerdigital/terraform-modules//modules/aws/ec2?ref=v2"
+  source = "github.com/answerdigital/terraform-modules//modules/aws/ec2?ref=v3"
 }
 ```
 
 Notice the double `//` between the repository URL and the path to the module.
 For further information please see the [terraform documentation](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories).
 
-Versions are shared across all modules. You can choose a specific tag (e.g. `?ref=v2.0.0`) or to get the latest changes within a major version, use `?ref=v2` which will get the latest v2.x.x release.
+Versions are shared across all modules. You can choose a specific tag (e.g. `?ref=v3.0.0`) or to get the latest changes within a major version, use `?ref=v3` which will get the latest v3.x.x release.
 
 ## Documentation
 

--- a/modules/aws/acme_certificate/README.md
+++ b/modules/aws/acme_certificate/README.md
@@ -78,7 +78,7 @@ data "aws_route53_zone" "test_com" {
 }
 
 module "test_project_test_com" {
-  source             = "github.com/answerdigital/terraform-modules//modules/aws/acme_certificate?ref=v2"
+  source             = "github.com/answerdigital/terraform-modules//modules/aws/acme_certificate?ref=v3"
   email_address      = local.dns_email_address
   aws_hosted_zone_id = data.aws_route53_zone.test_com.zone_id
   base_domain_name   = local.base_domain_name

--- a/modules/aws/ec2/README.md
+++ b/modules/aws/ec2/README.md
@@ -69,7 +69,7 @@ locals {
 }
 
 module "vpc_subnet" {
-  source               = "github.com/answerdigital/terraform-modules//modules/aws/vpc?ref=v2"
+  source               = "github.com/answerdigital/terraform-modules//modules/aws/vpc?ref=v3"
   owner                = local.owner
   project_name         = local.project
   enable_vpc_flow_logs = true
@@ -97,7 +97,7 @@ data "aws_availability_zones" "available" {
 }
 
 module "ec2_instance_setup" {
-  source                 = "github.com/answerdigital/terraform-modules//modules/aws/ec2?ref=v2"
+  source                 = "github.com/answerdigital/terraform-modules//modules/aws/ec2?ref=v3"
   project_name           = local.project
   owner                  = local.owner
   ami_id                 = data.aws_ami.ec2_ami.id

--- a/modules/aws/rds_serverless_cluster/README.md
+++ b/modules/aws/rds_serverless_cluster/README.md
@@ -76,7 +76,7 @@ Below is an example of how you would call the `rds_serverless_cluster` module in
 
 ```hcl
 module "rds_cluster_setup" {
-  source                     = "github.com/answerdigital/terraform-modules//modules/aws/rds_serverless_cluster?ref=v2"
+  source                     = "github.com/answerdigital/terraform-modules//modules/aws/rds_serverless_cluster?ref=v3"
   project_name               = var.project_name
   owner                      = var.owner
   database_availability_zone = module.vpc_subnet_setup.az_zones[0]

--- a/modules/aws/route53/README.md
+++ b/modules/aws/route53/README.md
@@ -68,7 +68,7 @@ Below is a simple example for an example.com zone with a single subdomain record
 
 ```terraform
 module "example_com" {
-  source = "github.com/answerdigital/terraform-modules//modules/aws/route53?ref=v2"
+  source = "github.com/answerdigital/terraform-modules//modules/aws/route53?ref=v3"
 
   domain = "example.com"
   records = {
@@ -91,7 +91,7 @@ the bare domain and www subdomain to the canonical domain.
 
 ```terraform
 module "example_com" {
-  source = "github.com/answerdigital/terraform-modules//modules/aws/route53?ref=v2"
+  source = "github.com/answerdigital/terraform-modules//modules/aws/route53?ref=v3"
 
   domain  = "example.com"
   aliases = [

--- a/modules/aws/sso_account_assignment/README.md
+++ b/modules/aws/sso_account_assignment/README.md
@@ -48,7 +48,7 @@ resource "aws_organizations_organization" "example" {
 }
 
 module "iam_example" {
-  source = "github.com/answerdigital/terraform-modules//modules/aws/sso_account_assignment?ref=v2"
+  source = "github.com/answerdigital/terraform-modules//modules/aws/sso_account_assignment?ref=v3"
 
   permission_sets = {
     AdministratorAccess = {

--- a/modules/aws/vpc/README.md
+++ b/modules/aws/vpc/README.md
@@ -82,14 +82,14 @@ and `eu-west-3` respectively.
 
 ```hcl
 module "vpc_subnet" {
-  source               = "github.com/answerdigital/terraform-modules//modules/aws/vpc?ref=v2"
+  source               = "github.com/answerdigital/terraform-modules//modules/aws/vpc?ref=v3"
   owner                = "joe_blogs"
   project_name         = "example_project_name"
   enable_vpc_flow_logs = true
 }
 
 module "vpc_subnet" {
-  source                     = "github.com/answerdigital/terraform-modules//modules/aws/vpc?ref=v2"
+  source                     = "github.com/answerdigital/terraform-modules//modules/aws/vpc?ref=v3"
   owner                      = "joe_blogs"
   project_name               = "example_project_name"
   azs                        = ["eu-west-1", "eu-west-3"]


### PR DESCRIPTION
EC2 module updated to use `hashicorp/aws` v5 in #64, so next release needs to be a major one.