### PR TITLE
SSO Account Assignment module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,15 @@ updates:
           - "version-update:semver-patch"
           - "version-update:semver-minor"
   - package-ecosystem: terraform
+    directory: /modules/aws/sso-account-assignment
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+  - package-ecosystem: terraform
     directory: /modules/aws/state_manager
     schedule:
       interval: daily

--- a/modules/aws/sso-account-assignment/README.md
+++ b/modules/aws/sso-account-assignment/README.md
@@ -4,6 +4,37 @@ This Terraform module creates permission sets and account assignments. This is
 to be used with AWS IAM Identity Center.
 
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_identitystore_group.internal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_group) | resource |
+| [aws_ssoadmin_account_assignment.to_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment) | resource |
+| [aws_ssoadmin_managed_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment) | resource |
+| [aws_ssoadmin_permission_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set) | resource |
+| [aws_identitystore_group.by_display_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group) | data source |
+| [aws_ssoadmin_instances.identity_center](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_assignments"></a> [assignments](#input\_assignments) | List of assignments between group, account and permission set. The key of each object is the group<br>    name that will be assigned the permissions. Ideally the organisation will use an external identity<br>    provider and this group should be created via SCIM. To also create the groups, enable `create_groups`.<br><br>    • `account_ids`     - (Required) The AWS account IDs to apply the assignment.<br>    • `permission_sets` - (Required) The Permission Sets to be assigned to the group. These should<br>                                     be a subset of the Permission Sets created above. | <pre>map(object({<br>    account_ids     = list(string)<br>    permission_sets = list(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_create_groups"></a> [create\_groups](#input\_create\_groups) | Whether the module should also create the groups. | `bool` | `false` | no |
+| <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | List of permission sets for the organization.<br><br>    • `name`             - (Optional) The name of the Permission Set. The key will be used by default.<br>    • `description`      - (Optional) The description of the Permission Set.<br>    • `managed_policies` - (Required) A list of managed policy names. The prefix `arn:aws:iam::aws:policy/`<br>                                      will be prepended to create the full ARN. | <pre>map(object({<br>    name             = optional(string)<br>    description      = optional(string)<br>    managed_policies = list(string)<br>  }))</pre> | n/a | yes |
 <!-- END_TF_DOCS -->
 
 # Example Usage

--- a/modules/aws/sso-account-assignment/README.md
+++ b/modules/aws/sso-account-assignment/README.md
@@ -1,0 +1,40 @@
+# Terraform SSO Account Assignment Module
+
+This Terraform module creates permission sets and account assignments. This is
+to be used with AWS IAM Identity Center.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->
+
+# Example Usage
+
+The following example creates a permission set "AdministratorAccess" which attaches
+the AWS managed policy also named AdministratorAccess. This permission set is then
+applied to the "SystemAdministrator" group across all accounts in the organisation.
+
+```hcl
+resource "aws_organizations_organization" "example" {
+}
+
+module "iam_example" {
+  source = "github.com/answerdigital/terraform-modules//modules/aws/sso-account-assignment?ref=v2"
+
+  permission_sets = {
+    AdministratorAccess = {
+      managed_policies = ["AdministratorAccess"]
+    }
+  }
+
+  assignments = {
+    "SystemAdministrator" = {
+      account_ids = [
+        for account in aws_organizations_organization.example.accounts : account.id
+      ]
+
+      permission_sets = [
+        "AdministratorAccess"
+      ]
+    }
+  }
+}
+```

--- a/modules/aws/sso-account-assignment/data.tf
+++ b/modules/aws/sso-account-assignment/data.tf
@@ -1,7 +1,8 @@
 data "aws_ssoadmin_instances" "identity_center" {}
 
+# look up by DisplayName when using pre-existing groups
 data "aws_identitystore_group" "by_display_name" {
-  for_each = local.groups
+  for_each = toset(var.create_groups ? [] : local.groups)
 
   identity_store_id = local.instance_identity_store_id
 

--- a/modules/aws/sso-account-assignment/data.tf
+++ b/modules/aws/sso-account-assignment/data.tf
@@ -1,0 +1,14 @@
+data "aws_ssoadmin_instances" "identity_center" {}
+
+data "aws_identitystore_group" "by_display_name" {
+  for_each = local.groups
+
+  identity_store_id = local.instance_identity_store_id
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = each.value
+    }
+  }
+}

--- a/modules/aws/sso-account-assignment/locals.tf
+++ b/modules/aws/sso-account-assignment/locals.tf
@@ -24,5 +24,5 @@ locals {
     ]
   ]))
 
-  groups = toset(keys(var.assignments))
+  groups = keys(var.assignments)
 }

--- a/modules/aws/sso-account-assignment/locals.tf
+++ b/modules/aws/sso-account-assignment/locals.tf
@@ -1,0 +1,28 @@
+locals {
+  instance_arn               = tolist(data.aws_ssoadmin_instances.identity_center.arns)[0]
+  instance_identity_store_id = tolist(data.aws_ssoadmin_instances.identity_center.identity_store_ids)[0]
+
+  managed_policies = flatten([
+    for permission_set, options in var.permission_sets : [
+      for policy in options.managed_policies : {
+        permission_set = permission_set
+        policy_name    = policy
+        policy_arn     = "arn:aws:iam::aws:policy/${policy}"
+      }
+    ]
+  ])
+
+  account_assignments = flatten(flatten([
+    for group, assignment in var.assignments : [
+      for permission_set in assignment.permission_sets : [
+        for account_id in assignment.account_ids : {
+          group          = group
+          account_id     = account_id
+          permission_set = permission_set
+        }
+      ]
+    ]
+  ]))
+
+  groups = toset(keys(var.assignments))
+}

--- a/modules/aws/sso-account-assignment/main.tf
+++ b/modules/aws/sso-account-assignment/main.tf
@@ -1,0 +1,28 @@
+resource "aws_ssoadmin_permission_set" "this" {
+  for_each = var.permission_sets
+
+  name         = each.value.name != null ? each.value.name : each.key
+  description  = each.value.description
+  instance_arn = local.instance_arn
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "this" {
+  for_each = { for p in local.managed_policies : "${p.permission_set}_${p.policy_name}" => p }
+
+  instance_arn       = local.instance_arn
+  managed_policy_arn = each.value.policy_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this[each.value.permission_set].arn
+}
+
+resource "aws_ssoadmin_account_assignment" "to_group" {
+  for_each = { for a in local.account_assignments : "${a.account_id}_${a.group}_${a.permission_set}" => a }
+
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this[each.value.permission_set].arn
+
+  principal_id   = data.aws_identitystore_group.by_display_name[each.value.group].group_id
+  principal_type = "GROUP"
+
+  target_id   = each.value.account_id
+  target_type = "AWS_ACCOUNT"
+}

--- a/modules/aws/sso-account-assignment/variables.tf
+++ b/modules/aws/sso-account-assignment/variables.tf
@@ -1,0 +1,30 @@
+variable "permission_sets" {
+  description = <<EOT
+    List of permission sets for the organization.
+    
+    • `name`             - (Optional) The name of the Permission Set. The key will be used by default.
+    • `description`      - (Optional) The description of the Permission Set.
+    • `managed_policies` - (Required) A list of managed policy names. The prefix `arn:aws:iam::aws:policy/`
+                                      will be prepended to create the full ARN.
+  EOT
+  type = map(object({
+    name             = optional(string)
+    description      = optional(string)
+    managed_policies = list(string)
+  }))
+}
+
+variable "assignments" {
+  description = <<EOT
+    List of assignments between group, account and permission set. The key of each object is the group
+    name that will be assigned the permissions. Ideally this group should be created via SCIM.
+    
+    • `account_ids`     - (Required) The AWS account IDs to apply the assignment.
+    • `permission_sets` - (Required) The Permission Sets to be assigned to the group. These should
+                                     be a subset of the Permission Sets created above.
+  EOT
+  type = map(object({
+    account_ids     = list(string)
+    permission_sets = list(string)
+  }))
+}

--- a/modules/aws/sso-account-assignment/variables.tf
+++ b/modules/aws/sso-account-assignment/variables.tf
@@ -17,7 +17,8 @@ variable "permission_sets" {
 variable "assignments" {
   description = <<EOT
     List of assignments between group, account and permission set. The key of each object is the group
-    name that will be assigned the permissions. Ideally this group should be created via SCIM.
+    name that will be assigned the permissions. Ideally the organisation will use an external identity
+    provider and this group should be created via SCIM. To also create the groups, enable `create_groups`.
     
     • `account_ids`     - (Required) The AWS account IDs to apply the assignment.
     • `permission_sets` - (Required) The Permission Sets to be assigned to the group. These should
@@ -27,4 +28,10 @@ variable "assignments" {
     account_ids     = list(string)
     permission_sets = list(string)
   }))
+}
+
+variable "create_groups" {
+  description = "Whether the module should also create the groups."
+  type        = bool
+  default     = false
 }

--- a/modules/aws/sso-account-assignment/versions.tf
+++ b/modules/aws/sso-account-assignment/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}


### PR DESCRIPTION
Simple module to create and assign permission sets to user groups.

Recommended to use with an external identity provider that creates user groups via SCIM, but it can create the user groups as well if required.