### PR TITLE
Fix the zone_id output when not creating the zone internally

### DIFF
--- a/modules/cloudflare/dns/dns.tf
+++ b/modules/cloudflare/dns/dns.tf
@@ -1,15 +1,15 @@
 data "cloudflare_zones" "lookup" {
-  count = var.create_zone ? 0 : 1
+  for_each = toset(var.create_zone ? [] : [var.domain])
 
   filter {
-    name       = var.domain
+    name       = each.value
     account_id = var.account_id
   }
 }
 
 resource "cloudflare_zone" "dns" {
-  count      = var.create_zone ? 1 : 0
-  zone       = var.domain
+  for_each   = toset(var.create_zone ? [var.domain] : [])
+  zone       = each.value
   account_id = var.account_id
 }
 

--- a/modules/cloudflare/dns/locals.tf
+++ b/modules/cloudflare/dns/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  zone_id = var.create_zone ? cloudflare_zone.dns[0].id : data.cloudflare_zones.lookup[0].id
+  zone_id = var.create_zone ? cloudflare_zone.dns[0].id : data.cloudflare_zones.lookup[0].zones[0].id
 
   security_contact = var.security_contact != null ? var.security_contact : format("security@%s", var.domain)
 }

--- a/modules/cloudflare/dns/locals.tf
+++ b/modules/cloudflare/dns/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  zone_id = var.create_zone ? cloudflare_zone.dns[0].id : data.cloudflare_zones.lookup[0].zones[0].id
+  zone_id = var.create_zone ? cloudflare_zone.dns[var.domain].id : data.cloudflare_zones.lookup[var.domain].zones[0].id
 
   security_contact = var.security_contact != null ? var.security_contact : format("security@%s", var.domain)
 }


### PR DESCRIPTION
Slight bug with grabbing the zone ID for zones that are not created as part of the module.