### PR TITLE
Cloudflare provider update to 5.1.0

### DIFF
--- a/modules/cloudflare/dns/README.md
+++ b/modules/cloudflare/dns/README.md
@@ -9,13 +9,13 @@ The module also simplifies a few boilerplate records at the apex for security pu
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 5.0.0 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 5.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | >= 5.0.0 |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | >= 5.1.0 |
 
 ## Resources
 

--- a/modules/cloudflare/dns/README.md
+++ b/modules/cloudflare/dns/README.md
@@ -9,21 +9,21 @@ The module also simplifies a few boilerplate records at the apex for security pu
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 4.39.0, < 5.0.0 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | >= 4.39.0, < 5.0.0 |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | >= 5.0.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [cloudflare_record.apex_txt](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
-| [cloudflare_record.caa](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
-| [cloudflare_record.dns](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record) | resource |
+| [cloudflare_dns_record.apex_txt](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
+| [cloudflare_dns_record.caa](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
+| [cloudflare_dns_record.dns](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
 | [cloudflare_zone.dns](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone) | resource |
 | [cloudflare_zones.lookup](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/zones) | data source |
 

--- a/modules/cloudflare/dns/dns.tf
+++ b/modules/cloudflare/dns/dns.tf
@@ -48,7 +48,7 @@ resource "cloudflare_dns_record" "caa" {
   type     = "CAA"
 
   data = {
-    flags = "0"
+    flags = 0
     tag   = "issue"
     value = each.value
   }

--- a/modules/cloudflare/dns/dns.tf
+++ b/modules/cloudflare/dns/dns.tf
@@ -1,19 +1,20 @@
 data "cloudflare_zones" "lookup" {
   for_each = toset(var.create_zone ? [] : [var.domain])
-
-  filter {
-    name       = each.value
-    account_id = var.account_id
+  name     = each.value
+  account = {
+    id = var.account_id
   }
 }
 
 resource "cloudflare_zone" "dns" {
-  for_each   = toset(var.create_zone ? [var.domain] : [])
-  zone       = each.value
-  account_id = var.account_id
+  for_each = toset(var.create_zone ? [var.domain] : [])
+  name     = each.value
+  account = {
+    id = var.account_id
+  }
 }
 
-resource "cloudflare_record" "dns" {
+resource "cloudflare_dns_record" "dns" {
   for_each = var.records
 
   zone_id  = local.zone_id
@@ -25,7 +26,7 @@ resource "cloudflare_record" "dns" {
   proxied  = each.value.proxied
 }
 
-resource "cloudflare_record" "apex_txt" {
+resource "cloudflare_dns_record" "apex_txt" {
   for_each = toset(concat(var.apex_txt, [
     format("security_contact=mailto:%s", local.security_contact),
     replace("v=spf1 ${join(" ", var.spf)} -all", "  ", " ")
@@ -39,13 +40,14 @@ resource "cloudflare_record" "apex_txt" {
   proxied = false
 }
 
-resource "cloudflare_record" "caa" {
+resource "cloudflare_dns_record" "caa" {
   for_each = toset(var.caa_issuers)
   zone_id  = local.zone_id
   name     = "@"
+  ttl      = var.default_ttl
   type     = "CAA"
 
-  data {
+  data = {
     flags = "0"
     tag   = "issue"
     value = each.value

--- a/modules/cloudflare/dns/locals.tf
+++ b/modules/cloudflare/dns/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  zone_id = var.create_zone ? cloudflare_zone.dns[var.domain].id : data.cloudflare_zones.lookup[var.domain].zones[0].id
+  zone_id = var.create_zone ? cloudflare_zone.dns[var.domain].id : data.cloudflare_zones.lookup[var.domain].result[0].id
 
   security_contact = var.security_contact != null ? var.security_contact : format("security@%s", var.domain)
 }

--- a/modules/cloudflare/dns/versions.tf
+++ b/modules/cloudflare/dns/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 4.39.0, < 5.0.0"
+      version = ">= 5.0.0"
     }
   }
 }

--- a/modules/cloudflare/dns/versions.tf
+++ b/modules/cloudflare/dns/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 5.0.0"
+      version = ">= 5.1.0"
     }
   }
 }


### PR DESCRIPTION
Version 5.0.0 is a major rewrite of the provider. Migration guide here: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/version-5-upgrade

We will need to provide more specific documentation for migrating from v4 to v5, as the process is not straightforward and Cloudflare's guidance does not work with modules.

This will also require a major bump of our repo, coincidentally from v4 to v5.